### PR TITLE
feat: release 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 3.3.0 (Vienna Panthers) - February 2019
+
+### New Features 3.3.0
+
+- Updated to version 3.3.0. of mindconnect library
+- added container build process on hub.docker.com
+- direct link to configuration settings in MindSphere from Node-RED UI
+- improved error handling
+
+### Bugfix 3.3.0
+
+- fixed the issue #3 Failed to load mindconnect node when modifying the URL root path #3
+
 ## 3.2.0 (Vienna Lynx) - January 2019
 
 ### New Features 3.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,35 +5,51 @@
   "requires": true,
   "dependencies": {
     "@mindconnect/mindconnect-nodejs": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@mindconnect/mindconnect-nodejs/-/mindconnect-nodejs-3.2.0.tgz",
-      "integrity": "sha512-Xr3+hCVC/Q4VAod0FCsJonAOKWX+lvayY1gU43ZoyHKG0xrY8QNOsOab/KLcs2G4v5iCh57Y8qvdtZi+iKVB1Q==",
+      "version": "3.3.0",
+      "resolved": "C:\\git\\github\\node-red-contrib-mindconnect\\mindconnect-mindconnect-nodejs-3.3.0.tgz",
+      "integrity": "sha512-i/9VN8zQZiFe0JN2kfhAeGPEdUboTQB2Zg8E9LryjNBNXFn99Yt46fWBEP28PhMqNyMAuUJGZf2OF6URdCz8mA==",
       "requires": {
-        "ajv": "^6.5.1",
-        "ajv-keywords": "^3.2.0",
-        "chalk": "^2.4.1",
-        "commander": "^2.16.0",
-        "csvtojson": "^2.0.6",
-        "debug": "^2.6.9",
+        "ajv": "^6.9.2",
+        "ajv-keywords": "^3.4.0",
+        "async-lock": "^1.1.4",
+        "buffer-concat": "^1.0.0",
+        "chalk": "^2.4.2",
+        "commander": "^2.19.0",
+        "csvtojson": "^2.0.8",
+        "debug": "^4.1.1",
         "https-proxy-agent": "^2.2.1",
         "json-groupby": "^1.1.0",
-        "jsonwebtoken": "^8.3.0",
-        "lodash": "^4.17.10",
-        "mime-types": "^2.1.19",
+        "jsonwebtoken": "^8.5.0",
+        "lodash": "^4.17.11",
+        "mime-types": "^2.1.22",
         "node-fetch": "^1.7.3",
-        "readline-sync": "^1.4.9",
         "rsa-pem-to-jwk": "^1.1.3",
-        "text-encoding": "^0.6.4",
-        "url-search-params-polyfill": "^4.0.0",
-        "uuid": "^3.2.1"
+        "url-search-params-polyfill": "^5.0.0",
+        "uuid": "^3.3.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+        "ajv": {
+          "version": "6.9.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
+          "integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
           "requires": {
-            "ms": "2.0.0"
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "mime-db": {
+          "version": "1.38.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+          "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
+        },
+        "mime-types": {
+          "version": "2.1.22",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+          "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+          "requires": {
+            "mime-db": "~1.38.0"
           }
         }
       }
@@ -150,9 +166,9 @@
       }
     },
     "ajv": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
-      "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
+      "integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -161,9 +177,9 @@
       }
     },
     "ajv-keywords": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-      "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
+      "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw=="
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -301,6 +317,11 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
       "dev": true
+    },
+    "async-lock": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.1.4.tgz",
+      "integrity": "sha512-9vsVXt+mIvb8rV0G6V1x68Bvp/VksPJoZJxF/n/l9N60chNJ44opPr9WdZZfAV3leUdXt4xNvfyNWyY/j5enBA=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1095,6 +1116,11 @@
           }
         }
       }
+    },
+    "buffer-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-concat/-/buffer-concat-1.0.0.tgz",
+      "integrity": "sha1-Le+trcsUXgrTwLlhzeGRCxGNH+Y="
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -1930,9 +1956,9 @@
       }
     },
     "ecdsa-sig-formatter": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
-      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -3773,11 +3799,11 @@
       }
     },
     "jsonwebtoken": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.4.0.tgz",
-      "integrity": "sha512-coyXjRTCy0pw5WYBpMvWOMN+Kjaik2MwTUIq9cna/W7NpO9E+iYbumZONAz3hcr+tXFJECoQVrtmIoC3Oz0gvg==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz",
+      "integrity": "sha512-IqEycp0znWHNA11TpYi77bVgyBO/pGESDh7Ajhas+u0ttkGkKYIIAjniL4Bw5+oVejVF+SYkaI7XKfwCCyeTuA==",
       "requires": {
-        "jws": "^3.1.5",
+        "jws": "^3.2.1",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -3785,13 +3811,19 @@
         "lodash.isplainobject": "^4.0.6",
         "lodash.isstring": "^4.0.1",
         "lodash.once": "^4.0.0",
-        "ms": "^2.1.1"
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
       },
       "dependencies": {
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "semver": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
         }
       }
     },
@@ -3808,21 +3840,21 @@
       }
     },
     "jwa": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
-      "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.3.0.tgz",
+      "integrity": "sha512-SxObIyzv9a6MYuZYaSN6DhSm9j3+qkokwvCB0/OTSV5ylPq1wUQiygZQcHT5Qlux0I5kmISx3J86TxKhuefItg==",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.10",
+        "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
     },
     "jws": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
-      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.1.tgz",
+      "integrity": "sha512-bGA2omSrFUkd72dhh05bIAN832znP4wOU3lfuXtRBuGTbsmNmDXMQg28f0Vsxaxgk4myF5YkKQpz6qeRpMgX9g==",
       "requires": {
-        "jwa": "^1.1.5",
+        "jwa": "^1.2.0",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -4143,12 +4175,14 @@
     "mime-db": {
       "version": "1.37.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.21",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
       "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "dev": true,
       "requires": {
         "mime-db": "~1.37.0"
       }
@@ -4274,7 +4308,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "multer": {
       "version": "1.4.1",
@@ -5085,11 +5120,6 @@
         "readable-stream": "^2.0.2"
       }
     },
-    "readline-sync": {
-      "version": "1.4.9",
-      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.9.tgz",
-      "integrity": "sha1-PtqOZfI80qF+YTAbHwADOWr17No="
-    },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -5748,11 +5778,6 @@
         "execa": "^0.7.0"
       }
     },
-    "text-encoding": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
-    },
     "through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
@@ -6201,9 +6226,9 @@
       }
     },
     "url-search-params-polyfill": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-4.0.1.tgz",
-      "integrity": "sha512-rf6qCTgcfNQp7lT6DIt8PLgksGIwzqW8KNVnIGGEjWOW4EbwD0sljPPXMqx4O0Pqfz/25+Y0NRu8Tf5UH9XmPg=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-5.0.0.tgz",
+      "integrity": "sha512-+SCD22QJp4UnqPOI5UTTR0Ljuh8cHbjEf1lIiZrZ8nHTlTixqwVsVQTSfk5vrmDz7N09/Y+ka5jQr0ff35FnQQ=="
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mindconnect/node-red-contrib-mindconnect",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "node red mindconnect node using mindconnect-nodejs library.",
   "main": "index.js",
   "scripts": {
@@ -39,8 +39,8 @@
     }
   },
   "dependencies": {
-    "@mindconnect/mindconnect-nodejs": "^3.2.0",
-    "ajv": "^6.9.1",
+    "@mindconnect/mindconnect-nodejs": "^3.3.0",
+    "ajv": "^6.9.2",
     "debug": "^4.1.1"
   }
 }

--- a/src/mindconnect.html
+++ b/src/mindconnect.html
@@ -6,7 +6,7 @@
     <div id="_msbar">
         <span  style="line-height:36px">
             &nbsp;&nbsp;MindConnect Node-RED Agent 
-        </span> <span style="color:#aaaaaa">v3.2.0</span>
+        </span> <span style="color:#aaaaaa">v3.3.0</span>
     </div>
 
     <div class="form-row">


### PR DESCRIPTION
## 3.3.0 (Vienna Panthers) - February 2019

### New Features 3.3.0

- Updated to version 3.3.0. of mindconnect library
- added container build process on hub.docker.com
- direct link to configuration settings in MindSphere from Node-RED UI
- improved error handling

### Bugfix 3.3.0

- fixed the issue #3 Failed to load mindconnect node when modifying the URL root path #3
